### PR TITLE
Fix an `undefined` error when trying to open a cdb file with an empty sheets array

### DIFF
--- a/src/Model.hx
+++ b/src/Model.hx
@@ -142,7 +142,7 @@ class Model {
 			base.load(sys.io.File.getContent(prefs.curFile));
 			if( prefs.curSheet > base.sheets.length )
 				prefs.curSheet = 0;
-			else while( base.sheets[prefs.curSheet].props.hide )
+			else while( prefs.curSheet > 0 && base.sheets[prefs.curSheet].props.hide )
 				prefs.curSheet--;
 		} catch( e : Dynamic ) {
 			if( !noError ) error(Std.string(e));


### PR DESCRIPTION
This small patch fixes an error if you try to open a file that didn't have any content added to it yet.

![Screenshot_20240602](https://github.com/dazKind/castle/assets/16482463/65c88fac-62f1-47fd-aa1f-c5837302f553)
